### PR TITLE
auto find files in assets folder

### DIFF
--- a/cocos2d-android/src/org/cocos2d/nodes/CCSprite.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCSprite.java
@@ -259,20 +259,35 @@ public class CCSprite extends CCNode implements CCRGBAProtocol, CCTextureProtoco
         return new CCSprite(spriteFrameName, isFrame);
     }
 
-    /** Creates an sprite with an image filename.
+    /** Creates an sprite with an image filepath.
       The rect used will be the size of the image.
       The offset will be (0,0).
       */
-    public static CCSprite sprite(String filename) {
-        return new CCSprite(filename);
+    public static CCSprite sprite(String filepath) {
+        return new CCSprite(filepath);
+    }
+
+    /** Creates an sprite with an image filepath and a rect.
+      The offset will be (0,0).
+      */
+    public static CCSprite sprite(String filepath, CGRect rect) {
+        return new CCSprite(filepath, rect);
+    }
+    
+    /** Creates an sprite with an image filename.
+    The rect used will be the size of the image.
+    The offset will be (0,0).
+    */
+    public static CCSprite sprite(String filepathstart, String filename) {
+        return new CCSprite(filepathstart, filename);
     }
 
     /** Creates an sprite with an image filename and a rect.
       The offset will be (0,0).
       */
-    public static CCSprite sprite(String filename, CGRect rect) {
-        return new CCSprite(filename, rect);
-    }
+    public static CCSprite sprite(String filepathstart, String filename, CGRect rect) {
+        return new CCSprite(filepathstart, filename, rect);
+    }	
 
     /** Creates an sprite with a CGImageRef.
      * BE AWARE OF the fact that copy of image is stored in memory,
@@ -356,34 +371,65 @@ public class CCSprite extends CCNode implements CCRGBAProtocol, CCTextureProtoco
         init(frame);
     }
 
-    /** Initializes an sprite with an image filename.
+    /** Initializes an sprite with an image filepath.
       The rect used will be the size of the image.
       The offset will be (0,0).
       */
-    public CCSprite(String filename) {
-        assert filename!=null:"Invalid filename for sprite";
+    public CCSprite(String filepath) {
+        assert filepath!=null:"Invalid filename for sprite";
 
-        CCTexture2D texture = CCTextureCache.sharedTextureCache().addImage(filename);
+        CCTexture2D texture = CCTextureCache.sharedTextureCache().addImage(filepath);
         if( texture != null) {
             CGRect rect = CGRect.make(0, 0, 0, 0);
             rect.size = texture.getContentSize();
             init(texture, rect);
         } else {
-		ccMacros.CCLOGERROR("CCSprite", "Unable to load texture from file: " + filename);
+		ccMacros.CCLOGERROR("CCSprite", "Unable to load texture from file: " + filepath);
         }
     }
+    
+    /** Initializes an sprite with an image filename
+    found by searching through the specified filepath.
+    The rect used will be the size of the image.
+    The offset will be (0,0).
+    */
+	  public CCSprite(String filepathstart, String filename) {
+	      assert filename!=null:"Invalid filename for sprite";
+	
+	      CCTexture2D texture = CCTextureCache.sharedTextureCache().addImage(filepathstart, filename);
+	      if( texture != null) {
+	          CGRect rect = CGRect.make(0, 0, 0, 0);
+	          rect.size = texture.getContentSize();
+	          init(texture, rect);
+	      } else {
+			ccMacros.CCLOGERROR("CCSprite", "Unable to load texture from file: " + filename);
+	      }
+	  }
 
     public CCSprite() {
     	init();
     }
     
-    /** Initializes an sprite with an image filename, and a rect.
+    /** Initializes an sprite with an image filepath, and a rect.
       The offset will be (0,0).
       */
-    public CCSprite(String filename, CGRect rect) {
+    public CCSprite(String filepath, CGRect rect) {
+        assert filepath!=null:"Invalid filename for sprite";
+
+        CCTexture2D texture = CCTextureCache.sharedTextureCache().addImage(filepath);
+        if( texture != null) {
+            init(texture, rect);
+        }
+    }
+    
+    /** Initializes an sprite with an image filename found by 
+    searching through the specified filepath, and a rect.
+    The offset will be (0,0).
+    */
+    public CCSprite(String filepathstart, String filename, CGRect rect) {
         assert filename!=null:"Invalid filename for sprite";
 
-        CCTexture2D texture = CCTextureCache.sharedTextureCache().addImage(filename);
+        CCTexture2D texture = CCTextureCache.sharedTextureCache().addImage(filepathstart, filename);
         if( texture != null) {
             init(texture, rect);
         }

--- a/cocos2d-android/src/org/cocos2d/nodes/CCTextureCache.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCTextureCache.java
@@ -72,6 +72,39 @@ public class CCTextureCache {
         return tex;
     }
     
+    /** Returns a Texture2D object given an file name
+     * If the file image was not previously loaded, it will create a new CCTexture2D
+     *  object and it will return it. It will use the filename as a key.
+     * Otherwise it will return a reference of a previosly loaded image.
+     * Supported image extensions: .png, .bmp, .tiff, .jpeg, .pvr, .gif
+     * 
+     * BE AWARE OF the fact that if you do not specify a start path
+     * then it will return the first found file of the given name.
+     * 
+     * Search the entire assets folder for "test.png"
+     * addImage("", "test.png") || addImage(null, "test.png")
+     * 
+     * Search the folder "Image" in assets for file "test.png"
+     * addImage("Image/", "test.png")
+     */
+    public CCTexture2D addImage(String pathStart, String fileName) {
+        assert fileName != null : "TextureMgr: fileName must not be null";
+        
+        String path = findFilePathInAssets(fileName, pathStart);
+        assert path != null : "TextureMgr: filePath could not be found from fileName or pathStart";
+        	
+        SoftReference<CCTexture2D> texSR = textures.get(path);
+        CCTexture2D tex = null;
+        if(texSR != null)
+        	tex = texSR.get();
+
+        if (tex == null) {
+            tex = createTextureFromFilePath(path);
+            textures.put(path, new SoftReference<CCTexture2D>(tex));
+        }
+        return tex;
+    }
+    
     /**
      * Returns a Texture2D object given an file image from external path.
      */
@@ -218,6 +251,40 @@ public class CCTextureCache {
         
         return tex;
     }
+    
+    private static String findFilePathInAssets(String fileName, String startPath)
+	{
+    	if (startPath == null)
+    		startPath = "";
+		try 
+		{
+			String[] list = CCDirector.sharedDirector().getActivity().getAssets().list(startPath);
+			if (list == null || list.length <= 0)
+				return null;
+			
+			for (String asset : list)
+			{
+				String filePath = (startPath.equals("") ? asset : startPath + "/" + asset);
+				
+				if (fileName.equals(asset))
+				{
+					return filePath;
+				}
+				else
+				{
+					String finalPath = findFilePathInAssets(fileName, filePath);
+					if (finalPath != null)
+						return finalPath;
+				}
+			}
+		}
+		catch (IOException e) 
+		{
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return null;
+	}
     
     private static CCTexture2D createTextureFromFilePathExternal(final String path) {
         

--- a/cocos2d-android/src/org/cocos2d/types/CGRect.java
+++ b/cocos2d-android/src/org/cocos2d/types/CGRect.java
@@ -11,6 +11,15 @@ public class CGRect {
     public CGRect(final CGPoint origin, final CGSize size) {
         this(origin.x, origin.y, size.width, size.height);
     }
+    
+    private static final CGRect ZERO_RECT = new CGRect(0, 0, 0, 0);
+    public static CGRect getZero() {
+    	return ZERO_RECT;
+    }
+    
+    public static CGRect zero() {
+        return new CGRect(0, 0, 0, 0);
+    }
 
     public static CGRect make(final CGPoint origin, final CGSize size) {
         return new CGRect(origin.x, origin.y, size.width, size.height);


### PR DESCRIPTION
Added zero method to CGRect to match CGSize and CGPoint.

Added auto search for filename in assets folder option to CCSprite.
Although not efficient removes hassle of updating file paths when you change a folder name.

Let me know what you think of the auto find. If people like this concept I will implement into other classes. Personally when working on a big project it can be a hassle to include filepath along with filename.
