### PR TITLE
A potential fix of slow gc

### DIFF
--- a/cocos2d-android/src/org/cocos2d/actions/CCActionManager.java
+++ b/cocos2d-android/src/org/cocos2d/actions/CCActionManager.java
@@ -94,6 +94,7 @@ public class CCActionManager implements UpdateCallback {
 		HashElement removedEl = targets.remove(element.target);//put(element.target, null);
     	
     	if(removedEl != null) {
+			removedEl.target = null;
 			pool.free( removedEl );
     	}
     }

--- a/cocos2d-android/src/org/cocos2d/utils/collections/ConcurrentArrayHashMap.java
+++ b/cocos2d-android/src/org/cocos2d/utils/collections/ConcurrentArrayHashMap.java
@@ -92,6 +92,9 @@ public class ConcurrentArrayHashMap<K,V> {
 		if(lastInd != 0)
 			array.get(lastInd - 1).next = null;
 		Entry removedEntry = array.remove(lastInd);
+		// should check for primitive type?
+		removedEntry.key = null;
+		removedEntry.value = null;
 		pool.free(removedEntry);
 		return ret;
 	}


### PR DESCRIPTION
Please consider if these two changes could help speed up gc by early removing strong references to potentially orphan nodes.
In my testing project which a huge scene hierarchy takes up lots of memory and many actions perform within, was never garbage collected after replaced by next smaller scene. After paying a whole night with Memory Analzyer there were two findings.
1. Some of the Nodes which performed actions in the huge scene is retained by the pool in ActionManager. After applying this fix gc really able reclaim the huge scene.
2. CCLabel's setString uses texture.setLoader which cause strong reference in GLResourceLoader's WeakHashMap entry. I can't think of a fix, any help will be appreciated.
