### PR TITLE
DalvikVM FloatBuffer.put() bug fix.

### DIFF
--- a/cocos2d-android/src/org/cocos2d/actions/CCProgressTimer.java
+++ b/cocos2d-android/src/org/cocos2d/actions/CCProgressTimer.java
@@ -1,7 +1,5 @@
 package org.cocos2d.actions;
 
-import java.nio.FloatBuffer;
-
 import javax.microedition.khronos.opengles.GL10;
 
 import org.cocos2d.config.ccConfig;
@@ -12,7 +10,7 @@ import org.cocos2d.opengl.CCTexture2D;
 import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.CGSize;
 import org.cocos2d.types.ccColor4F;
-import org.cocos2d.utils.BufferProvider;
+import org.cocos2d.utils.FastFloatBuffer;
 
 
 /**
@@ -66,18 +64,18 @@ public class CCProgressTimer extends CCNode {
         return sprite_;
     }
 
-    protected FloatBuffer textureCoordinates	= null;
-    protected FloatBuffer vertexCoordinates		= null;
-    protected FloatBuffer colors				= null;
+    protected FastFloatBuffer textureCoordinates	= null;
+    protected FastFloatBuffer vertexCoordinates		= null;
+    protected FastFloatBuffer colors				= null;
 	protected int		  vertexDataCount_		= 0;
 	// ccV2F_C4F_T2F	[]  vertexData_;
 
 	protected void setVertexDataCount(int cnt) {
 		vertexDataCount_ = cnt;
 		
-		textureCoordinates = BufferProvider.createFloatBuffer(2 * vertexDataCount_);
-		vertexCoordinates  = BufferProvider.createFloatBuffer(2 * vertexDataCount_);
-        colors    = BufferProvider.createFloatBuffer(4 * vertexDataCount_);
+		textureCoordinates = new FastFloatBuffer(2 * vertexDataCount_);
+		vertexCoordinates  = new FastFloatBuffer(2 * vertexDataCount_);
+        colors    = new FastFloatBuffer(4 * vertexDataCount_);
 	}
 	
 	protected void resetVertex() {
@@ -559,9 +557,9 @@ public class CCProgressTimer extends CCNode {
         
         gl.glBindTexture(GL10.GL_TEXTURE_2D, sprite_.getTexture().name());
 
-        gl.glVertexPointer(2, GL10.GL_FLOAT, 0, this.vertexCoordinates);
-        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, this.textureCoordinates);
-        gl.glColorPointer(4, GL10.GL_FLOAT, 0, this.colors);
+        gl.glVertexPointer(2, GL10.GL_FLOAT, 0, this.vertexCoordinates.bytes);
+        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, this.textureCoordinates.bytes);
+        gl.glColorPointer(4, GL10.GL_FLOAT, 0, this.colors.bytes);
 
         if (type_ == kCCProgressTimerTypeRadialCCW || type_ == kCCProgressTimerTypeRadialCW){
             gl.glDrawArrays(GL10.GL_TRIANGLE_FAN, 0, vertexDataCount_);

--- a/cocos2d-android/src/org/cocos2d/grid/CCGrid3D.java
+++ b/cocos2d-android/src/org/cocos2d/grid/CCGrid3D.java
@@ -11,17 +11,18 @@ import org.cocos2d.types.CCVertex3D;
 import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.ccGridSize;
 import org.cocos2d.types.ccQuad3;
+import org.cocos2d.utils.FastFloatBuffer;
 
 
 /**
  CCGrid3D is a 3D grid implementation. Each vertex has 3 dimensions: x,y,z
  */
 public class CCGrid3D extends CCGridBase {
-	protected FloatBuffer texCoordinates;
-	protected FloatBuffer vertices;
-	protected FloatBuffer originalVertices;
+	protected FastFloatBuffer texCoordinates;
+	protected FastFloatBuffer vertices;
+	protected FastFloatBuffer originalVertices;
     protected ShortBuffer indices;
-    protected FloatBuffer mVertexBuffer;
+    protected FastFloatBuffer mVertexBuffer;
 
     public CCGrid3D(ccGridSize gSize) {
         super(gSize);
@@ -40,7 +41,7 @@ public class CCGrid3D extends CCGridBase {
         ByteBuffer vbb = ByteBuffer.allocateDirect(vertices.limit()*3*4);
         //System.out.printf("vertices limit = %d\n", vertices.limit());
         vbb.order(ByteOrder.nativeOrder());
-        mVertexBuffer = vbb.asFloatBuffer();            
+        mVertexBuffer = FastFloatBuffer.createBuffer(vbb);            
         mVertexBuffer.clear();          
         mVertexBuffer.position(0);
         for (int i = 0; i < vertices.limit(); i=i+3) {            
@@ -49,9 +50,9 @@ public class CCGrid3D extends CCGridBase {
             mVertexBuffer.put(vertices.get(i+2));
         }
         mVertexBuffer.position(0);
-        gl.glVertexPointer(3, GL10.GL_FLOAT, 0, mVertexBuffer);
+        gl.glVertexPointer(3, GL10.GL_FLOAT, 0, mVertexBuffer.bytes);
         // gl.glVertexPointer(3, GL10.GL_FLOAT, 0, vertices);
-        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, texCoordinates);
+        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, texCoordinates.bytes);
         indices.position(0);
 
         gl.glDrawElements(GL10.GL_TRIANGLES, n * 6, GL10.GL_UNSIGNED_SHORT, indices);
@@ -70,17 +71,17 @@ public class CCGrid3D extends CCGridBase {
 
         ByteBuffer vfb = ByteBuffer.allocateDirect(ccQuad3.size * (gridSize_.x + 1) * (gridSize_.y + 1) * 4);
         vfb.order(ByteOrder.nativeOrder());
-        vertices = vfb.asFloatBuffer();
+        vertices = FastFloatBuffer.createBuffer(vfb);
         // vertices = BufferProvider.createFloatBuffer(ccQuad3.size * (gridSize_.x + 1) * (gridSize_.y + 1));
 
         ByteBuffer ofb = ByteBuffer.allocateDirect(ccQuad3.size * (gridSize_.x + 1) * (gridSize_.y + 1) * 4);
         ofb.order(ByteOrder.nativeOrder());
-        originalVertices = ofb.asFloatBuffer();
+        originalVertices = FastFloatBuffer.createBuffer(ofb);
         // originalVertices = BufferProvider.createFloatBuffer(ccQuad3.size * (gridSize_.x + 1) * (gridSize_.y + 1));
                 
         ByteBuffer tfb = ByteBuffer.allocateDirect(2 * (gridSize_.x + 1) * (gridSize_.y + 1) * 4);
         tfb.order(ByteOrder.nativeOrder());
-        texCoordinates = tfb.asFloatBuffer();
+        texCoordinates = FastFloatBuffer.createBuffer(tfb);
         // texCoordinates = BufferProvider.createFloatBuffer(2 * (gridSize_.x + 1) * (gridSize_.y + 1));
         
         ByteBuffer isb = ByteBuffer.allocateDirect(6 * (gridSize_.x + 1) * (gridSize_.y + 1) * 2);

--- a/cocos2d-android/src/org/cocos2d/grid/CCTiledGrid3D.java
+++ b/cocos2d-android/src/org/cocos2d/grid/CCTiledGrid3D.java
@@ -1,14 +1,15 @@
 package org.cocos2d.grid;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.ShortBuffer;
+
+import javax.microedition.khronos.opengles.GL10;
+
 import org.cocos2d.types.ccGridSize;
 import org.cocos2d.types.ccQuad2;
 import org.cocos2d.types.ccQuad3;
-
-import javax.microedition.khronos.opengles.GL10;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
-import java.nio.ShortBuffer;
+import org.cocos2d.utils.FastFloatBuffer;
 
 
 /**
@@ -17,9 +18,9 @@ import java.nio.ShortBuffer;
 */
 
 public class CCTiledGrid3D extends CCGridBase {
-    FloatBuffer texCoordinates;
-    FloatBuffer vertices;
-    FloatBuffer originalVertices;
+    FastFloatBuffer texCoordinates;
+    FastFloatBuffer vertices;
+    FastFloatBuffer originalVertices;
     ShortBuffer indices;
 
     public static CCTiledGrid3D make(ccGridSize gSize) {
@@ -39,8 +40,8 @@ public class CCTiledGrid3D extends CCGridBase {
     	// Unneeded states: GL_COLOR_ARRAY
         gl.glDisableClientState(GL10.GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(3, GL10.GL_FLOAT, 0, vertices);
-        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, texCoordinates);
+        gl.glVertexPointer(3, GL10.GL_FLOAT, 0, vertices.bytes);
+        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, texCoordinates.bytes);
         gl.glDrawElements(GL10.GL_TRIANGLES, n * 6, GL10.GL_UNSIGNED_SHORT, indices);
 
         gl.glEnableClientState(GL10.GL_COLOR_ARRAY);
@@ -129,15 +130,15 @@ public class CCTiledGrid3D extends CCGridBase {
 
         ByteBuffer vfb = ByteBuffer.allocateDirect(ccQuad3.size * numQuads * 4);
         vfb.order(ByteOrder.nativeOrder());
-        vertices = vfb.asFloatBuffer();
+        vertices = FastFloatBuffer.createBuffer(vfb);
 
         ByteBuffer ofb = ByteBuffer.allocateDirect(ccQuad3.size * numQuads * 4);
         ofb.order(ByteOrder.nativeOrder());
-        originalVertices = ofb.asFloatBuffer();
+        originalVertices = FastFloatBuffer.createBuffer(ofb);
 
         ByteBuffer tfb = ByteBuffer.allocateDirect(ccQuad2.size * numQuads * 4);
         tfb.order(ByteOrder.nativeOrder());
-        texCoordinates = tfb.asFloatBuffer();
+        texCoordinates = FastFloatBuffer.createBuffer(tfb);
 
         ByteBuffer isb = ByteBuffer.allocateDirect(6 * numQuads * 2);
         isb.order(ByteOrder.nativeOrder());

--- a/cocos2d-android/src/org/cocos2d/layers/CCColorLayer.java
+++ b/cocos2d-android/src/org/cocos2d/layers/CCColorLayer.java
@@ -2,7 +2,6 @@ package org.cocos2d.layers;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
 
 import javax.microedition.khronos.opengles.GL10;
 
@@ -14,6 +13,7 @@ import org.cocos2d.types.CGSize;
 import org.cocos2d.types.ccBlendFunc;
 import org.cocos2d.types.ccColor3B;
 import org.cocos2d.types.ccColor4B;
+import org.cocos2d.utils.FastFloatBuffer;
 
 //
 // CCColorLayer
@@ -33,8 +33,8 @@ public class CCColorLayer extends CCLayer
     /** BlendFunction. Conforms to CCBlendProtocol protocol */
 	protected ccBlendFunc	blendFunc_;
 
-    private FloatBuffer squareVertices_;
-    private FloatBuffer squareColors_;
+    private FastFloatBuffer squareVertices_;
+    private FastFloatBuffer squareColors_;
 
     /** creates a CCLayer with color. Width and height are the window size. */
     public static CCColorLayer node(ccColor4B color) {
@@ -61,11 +61,11 @@ public class CCColorLayer extends CCLayer
     protected void init(ccColor4B color, float w, float h) {
         ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * 4);
         vbb.order(ByteOrder.nativeOrder());
-        squareVertices_ = vbb.asFloatBuffer();
+        squareVertices_ = FastFloatBuffer.createBuffer(vbb);
 
         ByteBuffer sbb = ByteBuffer.allocateDirect(4 * 4 * 4);
         sbb.order(ByteOrder.nativeOrder());
-        squareColors_ = sbb.asFloatBuffer();
+        squareColors_ = FastFloatBuffer.createBuffer(sbb);
 
         color_ = new ccColor3B(color.r, color.g, color.b);
         opacity_ = color.a;
@@ -107,8 +107,8 @@ public class CCColorLayer extends CCLayer
         gl.glDisableClientState(GL10.GL_TEXTURE_COORD_ARRAY);
         gl.glDisable(GL10.GL_TEXTURE_2D);
 
-        gl.glVertexPointer(2, GL10.GL_FLOAT, 0, squareVertices_);
-        gl.glColorPointer(4, GL10.GL_FLOAT, 0, squareColors_);
+        gl.glVertexPointer(2, GL10.GL_FLOAT, 0, squareVertices_.bytes);
+        gl.glColorPointer(4, GL10.GL_FLOAT, 0, squareColors_.bytes);
 
         boolean newBlend = false;
         if (blendFunc_.src != ccConfig.CC_BLEND_SRC || blendFunc_.dst != ccConfig.CC_BLEND_DST) {

--- a/cocos2d-android/src/org/cocos2d/nodes/CCDirector.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCDirector.java
@@ -448,8 +448,8 @@ public class CCDirector implements GLSurfaceView.Renderer {
     private double oldAnimationInterval_;
 //    private Timer  animationTimer_;
 
-    public void getAnimationInterval(double interval) {
-        animationInterval_ = interval;
+    public double getAnimationInterval() {
+        return animationInterval_;
     }
 
     public void setAnimationInterval(double interval) {

--- a/cocos2d-android/src/org/cocos2d/nodes/CCRibbon.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCRibbon.java
@@ -2,7 +2,6 @@ package org.cocos2d.nodes;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
 import java.util.ArrayList;
 
 import javax.microedition.khronos.opengles.GL10;
@@ -13,6 +12,7 @@ import org.cocos2d.types.CCTexParams;
 import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.ccBlendFunc;
 import org.cocos2d.types.ccColor4B;
+import org.cocos2d.utils.FastFloatBuffer;
 
 /**
  * A ribbon is a dynamically generated list of polygons drawn as a single or series
@@ -43,22 +43,22 @@ public class CCRibbon extends CCNode {
         int end;
         int begin;
 
-        FloatBuffer mVertices;
-        FloatBuffer mCoordinates;
-        FloatBuffer mColors;
+        FastFloatBuffer mVertices;
+        FastFloatBuffer mCoordinates;
+        FastFloatBuffer mColors;
 
         public CCRibbonSegment() {
             ByteBuffer vfb = ByteBuffer.allocateDirect(COUNT * 3 * 2 * 4);
             vfb.order(ByteOrder.nativeOrder());
-            mVertices = vfb.asFloatBuffer();
+            mVertices = FastFloatBuffer.createBuffer(vfb);
 
             ByteBuffer tfb = ByteBuffer.allocateDirect(COUNT * 2 * 2 * 4);
             tfb.order(ByteOrder.nativeOrder());
-            mCoordinates = tfb.asFloatBuffer();
+            mCoordinates = FastFloatBuffer.createBuffer(tfb);
 
             ByteBuffer cbb = ByteBuffer.allocateDirect(COUNT * 4 * 2 * 4);
             cbb.order(ByteOrder.nativeOrder());
-            mColors = cbb.asFloatBuffer();
+            mColors = FastFloatBuffer.createBuffer(cbb);
 
             reset();
         }
@@ -107,18 +107,18 @@ public class CCRibbon extends CCNode {
                     mColors.put(colors, begin * 4 * 2, (end - begin) * 4 * 2);
                     mColors.position(0);
 
-                    gl.glColorPointer(4, GL10.GL_FLOAT, 0, mColors);
+                    gl.glColorPointer(4, GL10.GL_FLOAT, 0, mColors.bytes);
                 }
 
                 mVertices.put(verts, begin * 3 * 2, (end - begin) * 3 * 2);
                 mVertices.position(0);
 
-                gl.glVertexPointer(3, GL10.GL_FLOAT, 0, mVertices);
+                gl.glVertexPointer(3, GL10.GL_FLOAT, 0, mVertices.bytes);
 
                 mCoordinates.put(coords, begin * 2 * 2, (end - begin) * 2 * 2);
                 mCoordinates.position(0);
 
-                gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, mCoordinates);
+                gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, mCoordinates.bytes);
                 gl.glDrawArrays(GL10.GL_TRIANGLE_STRIP, 0, (end - begin) * 2);
             } else
                 finished = true;

--- a/cocos2d-android/src/org/cocos2d/nodes/CCSprite.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCSprite.java
@@ -1,6 +1,5 @@
 package org.cocos2d.nodes;
 
-import java.nio.FloatBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -19,7 +18,7 @@ import org.cocos2d.types.CGSize;
 import org.cocos2d.types.ccBlendFunc;
 import org.cocos2d.types.ccColor3B;
 import org.cocos2d.types.ccColor4B;
-import org.cocos2d.utils.BufferProvider;
+import org.cocos2d.utils.FastFloatBuffer;
 
 import android.graphics.Bitmap;
 
@@ -190,31 +189,31 @@ public class CCSprite extends CCNode implements CCRGBAProtocol, CCTextureProtoco
 	// vertex coords, texture coords and color info
     /** buffers that are going to be rendered */
     /** the quad (tex coords, vertex coords and color) information */
-    private FloatBuffer texCoords;
+    private FastFloatBuffer texCoords;
     public float[] getTexCoordsArray() {
     	float ret[] = new float[texCoords.limit()];
     	texCoords.get(ret, 0, texCoords.limit());
     	return ret;
     }
     
-    private FloatBuffer vertexes;
+    private FastFloatBuffer vertexes;
     public float[] getVertexArray() {
     	float ret[] = new float[vertexes.limit()];
     	vertexes.get(ret, 0, vertexes.limit());
     	return ret;
     }
     
-    public FloatBuffer getTexCoords() {
+    public FastFloatBuffer getTexCoords() {
     	texCoords.position(0);
     	return texCoords;
     }
     
-    public FloatBuffer getVertices() {
+    public FastFloatBuffer getVertices() {
     	vertexes.position(0);
     	return vertexes;
     }
     
-    private FloatBuffer colors;
+    private FastFloatBuffer colors;
 
 	// whether or not it's parent is a CCSpriteSheet
     /** whether or not the Sprite is rendered using a CCSpriteSheet */
@@ -486,9 +485,9 @@ public class CCSprite extends CCNode implements CCRGBAProtocol, CCTextureProtoco
     }
 
     protected void init() {
-        texCoords = BufferProvider.createFloatBuffer(4 * 2);
-        vertexes  = BufferProvider.createFloatBuffer(4 * 3);
-        colors    = BufferProvider.createFloatBuffer(4 * 4);
+        texCoords = new FastFloatBuffer(4 * 2);
+        vertexes  = new FastFloatBuffer(4 * 3);
+        colors    = new FastFloatBuffer(4 * 4);
     	
 		dirty_ = false;
         recursiveDirty_ = false;
@@ -899,15 +898,15 @@ public class CCSprite extends CCNode implements CCRGBAProtocol, CCTextureProtoco
 
         // vertex
         // int diff = offsetof( ccV3F_C4B_T2F, vertices);
-        gl.glVertexPointer(3, GL10.GL_FLOAT, 0 , vertexes);
+        gl.glVertexPointer(3, GL10.GL_FLOAT, 0 , vertexes.bytes);
 
         // color
         // diff = offsetof( ccV3F_C4B_T2F, colors);
-        gl.glColorPointer(4, GL10.GL_FLOAT, 0, colors);
+        gl.glColorPointer(4, GL10.GL_FLOAT, 0, colors.bytes);
 
         // tex coords
         // diff = offsetof( ccV3F_C4B_T2F, texCoords);
-        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, texCoords);
+        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, texCoords.bytes);
 
         gl.glDrawArrays(GL10.GL_TRIANGLE_STRIP, 0, 4);
 

--- a/cocos2d-android/src/org/cocos2d/nodes/CCSpriteSheet.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCSpriteSheet.java
@@ -1,6 +1,5 @@
 package org.cocos2d.nodes;
 
-import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,6 +14,7 @@ import org.cocos2d.protocols.CCTextureProtocol;
 import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.CGRect;
 import org.cocos2d.types.ccBlendFunc;
+import org.cocos2d.utils.FastFloatBuffer;
 
 /** CCSpriteSheet is like a batch node: if it contains children, it will draw them in 1 single OpenGL call
  * (often known as "batch draw").
@@ -476,8 +476,8 @@ public class CCSpriteSheet extends CCNode implements CCTextureProtocol {
 		sprite.useSpriteSheetRender(this);
 		sprite.atlasIndex	= index;
 
-		FloatBuffer texCordBuffer = sprite.getTexCoords();
-		FloatBuffer vertexBuffer  = sprite.getVertices();
+		FastFloatBuffer texCordBuffer = sprite.getTexCoords();
+		FastFloatBuffer vertexBuffer  = sprite.getVertices();
 		textureAtlas_.insertQuad(texCordBuffer, vertexBuffer, index);
 
 		// XXX: updateTransform will update the textureAtlas too using updateQuad.

--- a/cocos2d-android/src/org/cocos2d/opengl/CCDrawingPrimitives.java
+++ b/cocos2d-android/src/org/cocos2d/opengl/CCDrawingPrimitives.java
@@ -1,13 +1,23 @@
 package org.cocos2d.opengl;
 
-import org.cocos2d.types.CGPoint;
-import org.cocos2d.types.CGRect;
+import static javax.microedition.khronos.opengles.GL10.GL_COLOR_ARRAY;
+import static javax.microedition.khronos.opengles.GL10.GL_FLOAT;
+import static javax.microedition.khronos.opengles.GL10.GL_LINES;
+import static javax.microedition.khronos.opengles.GL10.GL_LINE_LOOP;
+import static javax.microedition.khronos.opengles.GL10.GL_LINE_STRIP;
+import static javax.microedition.khronos.opengles.GL10.GL_POINTS;
+import static javax.microedition.khronos.opengles.GL10.GL_TEXTURE_2D;
+import static javax.microedition.khronos.opengles.GL10.GL_TEXTURE_COORD_ARRAY;
 
-import javax.microedition.khronos.opengles.GL10;
-import static javax.microedition.khronos.opengles.GL10.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
+
+import javax.microedition.khronos.opengles.GL10;
+
+import org.cocos2d.types.CGPoint;
+import org.cocos2d.types.CGRect;
+import org.cocos2d.utils.FastFloatBuffer;
 
 /**
  @file
@@ -24,13 +34,13 @@ import java.nio.FloatBuffer;
 */
 public class CCDrawingPrimitives {
 	
-	private static FloatBuffer tmpFloatBuf;
+	private static FastFloatBuffer tmpFloatBuf;
 	
-	private static FloatBuffer getVertices(int size) {
+	private static FastFloatBuffer getVertices(int size) {
 		if(tmpFloatBuf == null || tmpFloatBuf.capacity() < size) {
 	        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * size);
 	        vbb.order(ByteOrder.nativeOrder());
-	        tmpFloatBuf = vbb.asFloatBuffer();
+	        tmpFloatBuf = FastFloatBuffer.createBuffer(vbb);
 		}
 		tmpFloatBuf.rewind();
 		return tmpFloatBuf;
@@ -41,7 +51,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * 1);
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * 1);
+        FastFloatBuffer vertices = getVertices(2 * 1);
 
         vertices.put(pnt.x);
         vertices.put(pnt.y);
@@ -54,7 +64,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL10.GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL10.GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         gl.glDrawArrays(GL_POINTS, 0, 1);
 
         // restore default state
@@ -70,7 +80,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * numberOfPoints);
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * numberOfPoints);
+        FastFloatBuffer vertices = getVertices(2 * numberOfPoints);
 
         for (int i = 0; i < numberOfPoints; i++) {
             vertices.put(points[i].x);
@@ -85,7 +95,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         gl.glDrawArrays(GL_POINTS, 0, numberOfPoints);
 
         // restore default state
@@ -99,7 +109,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * 2);
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * 2);
+        FastFloatBuffer vertices = getVertices(2 * 2);
 
         vertices.put(origin.x);
         vertices.put(origin.y);
@@ -114,7 +124,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         gl.glDrawArrays(GL_LINES, 0, 2);
 
         // restore default state
@@ -142,7 +152,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * numberOfPoints);
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * numberOfPoints);
+        FastFloatBuffer vertices = getVertices(2 * numberOfPoints);
 
         for (int i = 0; i < numberOfPoints; i++) {
             vertices.put(poli[i].x);
@@ -157,7 +167,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         if (closePolygon)
             gl.glDrawArrays(GL_LINE_LOOP, 0, numberOfPoints);
         else
@@ -176,7 +186,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * (segments + 2));
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * (segments + 2));
+        FastFloatBuffer vertices = getVertices(2 * (segments + 2));
 
         int additionalSegment = 1;
 
@@ -204,7 +214,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         gl.glDrawArrays(GL_LINE_STRIP, 0, segments + additionalSegment);
 
         // restore default state
@@ -220,7 +230,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * (segments + 1));
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * (segments + 1));
+        FastFloatBuffer vertices = getVertices(2 * (segments + 1));
         
         float t = 0.0f;
         for(int i = 0; i < segments; i++) {
@@ -242,7 +252,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL10.GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL10.GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         gl.glDrawArrays(GL_LINE_STRIP, 0, segments + 1);
 
         // restore default state
@@ -261,7 +271,7 @@ public class CCDrawingPrimitives {
 //        ByteBuffer vbb = ByteBuffer.allocateDirect(4 * 2 * (segments + 1));
 //        vbb.order(ByteOrder.nativeOrder());
 //        FloatBuffer vertices = vbb.asFloatBuffer();
-        FloatBuffer vertices = getVertices(2 * (segments + 1));
+        FastFloatBuffer vertices = getVertices(2 * (segments + 1));
 
         float t = 0;
         for(int i = 0; i < segments; i++)
@@ -284,7 +294,7 @@ public class CCDrawingPrimitives {
         gl.glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL_COLOR_ARRAY);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, vertices);
+        gl.glVertexPointer(2, GL_FLOAT, 0, vertices.bytes);
         gl.glDrawArrays(GL_LINE_STRIP, 0, segments + 1);
         
         // restore default state

--- a/cocos2d-android/src/org/cocos2d/opengl/CCTexture2D.java
+++ b/cocos2d-android/src/org/cocos2d/opengl/CCTexture2D.java
@@ -31,6 +31,7 @@ import org.cocos2d.types.CCTexParams;
 import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.CGRect;
 import org.cocos2d.types.CGSize;
+import org.cocos2d.utils.FastFloatBuffer;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -112,8 +113,8 @@ public class CCTexture2D implements Resource {
         return premultipliedAlpha;
     }
     
-    private FloatBuffer mVertices;
-    private FloatBuffer mCoordinates;
+    private FastFloatBuffer mVertices;
+    private FastFloatBuffer mCoordinates;
 //    private ShortBuffer mIndices;
 
     /** this mBitmap should be created when we call load(),
@@ -281,11 +282,11 @@ public class CCTexture2D implements Resource {
         _maxT = mContentSize.height / (float) mHeight;
         ByteBuffer vfb = ByteBuffer.allocateDirect(4 * 3 * 4);
         vfb.order(ByteOrder.nativeOrder());
-        mVertices = vfb.asFloatBuffer();
+        mVertices = FastFloatBuffer.createBuffer(vfb);
 
         ByteBuffer tfb = ByteBuffer.allocateDirect(4 * 2 * 4);
         tfb.order(ByteOrder.nativeOrder());
-        mCoordinates = tfb.asFloatBuffer();
+        mCoordinates = FastFloatBuffer.createBuffer(tfb);
         
         // GLUtils.texImage2D makes premultiplied alpha
 		if(mBitmap.getConfig() == Bitmap.Config.ARGB_8888)
@@ -519,8 +520,8 @@ public class CCTexture2D implements Resource {
         gl.glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
         gl.glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-        gl.glVertexPointer(3, GL_FLOAT, 0, mVertices);
-        gl.glTexCoordPointer(2, GL_FLOAT, 0, mCoordinates);
+        gl.glVertexPointer(3, GL_FLOAT, 0, mVertices.bytes);
+        gl.glTexCoordPointer(2, GL_FLOAT, 0, mCoordinates.bytes);
         gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
         // Clear the vertex and color arrays
@@ -565,8 +566,8 @@ public class CCTexture2D implements Resource {
         gl.glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
         gl.glTexParameterx(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-        gl.glVertexPointer(2, GL_FLOAT, 0, mVertices);
-        gl.glTexCoordPointer(2, GL_FLOAT, 0, mCoordinates);
+        gl.glVertexPointer(2, GL_FLOAT, 0, mVertices.bytes);
+        gl.glTexCoordPointer(2, GL_FLOAT, 0, mCoordinates.bytes);
         gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
         // Clear the vertex and color arrays

--- a/cocos2d-android/src/org/cocos2d/particlesystem/CCPointParticleSystem.java
+++ b/cocos2d-android/src/org/cocos2d/particlesystem/CCPointParticleSystem.java
@@ -1,7 +1,5 @@
 package org.cocos2d.particlesystem;
 
-import java.nio.FloatBuffer;
-
 import javax.microedition.khronos.opengles.GL11;
 
 import org.cocos2d.config.ccConfig;
@@ -10,7 +8,7 @@ import org.cocos2d.nodes.CCDirector;
 import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.ccBlendFunc;
 import org.cocos2d.types.ccPointSprite;
-import org.cocos2d.utils.BufferProvider;
+import org.cocos2d.utils.FastFloatBuffer;
 
 /** CCPointParticleSystem is a subclass of CCParticleSystem
  Attributes of a Particle System:
@@ -26,9 +24,9 @@ import org.cocos2d.utils.BufferProvider;
  */
 public class CCPointParticleSystem extends CCParticleSystem {
 	// Array of (x,y, ccColor4F) 
-	FloatBuffer vertices;
+	FastFloatBuffer vertices;
 	// Array of (size)
-	FloatBuffer sizeBuffer;
+	FastFloatBuffer sizeBuffer;
 
 	// vertices buffer id
 	int	verticesID[];    
@@ -38,18 +36,18 @@ public class CCPointParticleSystem extends CCParticleSystem {
 
         GL11 gl = (GL11) CCDirector.gl;
 
-        vertices = BufferProvider.createFloatBuffer(numberOfParticles * ccPointSprite.spriteSize);
-        sizeBuffer = BufferProvider.createFloatBuffer(numberOfParticles);
+        vertices = new FastFloatBuffer(numberOfParticles * ccPointSprite.spriteSize);
+        sizeBuffer = new FastFloatBuffer(numberOfParticles);
         
         verticesID = new int[2];
         gl.glGenBuffers(2, verticesID, 0);
 
         // initial binding
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, verticesID[0]);
-        gl.glBufferData(GL11.GL_ARRAY_BUFFER, ccPointSprite.spriteSize*4*totalParticles, vertices, GL11.GL_DYNAMIC_DRAW);
+        gl.glBufferData(GL11.GL_ARRAY_BUFFER, ccPointSprite.spriteSize*4*totalParticles, vertices.bytes, GL11.GL_DYNAMIC_DRAW);
         
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, verticesID[1]);
-        gl.glBufferData(GL11.GL_ARRAY_BUFFER, 4*totalParticles, sizeBuffer, GL11.GL_DYNAMIC_DRAW);
+        gl.glBufferData(GL11.GL_ARRAY_BUFFER, 4*totalParticles, sizeBuffer.bytes, GL11.GL_DYNAMIC_DRAW);
         
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, 0);
     }
@@ -80,10 +78,10 @@ public class CCPointParticleSystem extends CCParticleSystem {
     public void postStep() {
     	GL11 gl = (GL11) CCDirector.gl;
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, verticesID[0]);
-        gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, ccPointSprite.spriteSize*4*particleCount, vertices);
+        gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, ccPointSprite.spriteSize*4*particleCount, vertices.bytes);
         
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, verticesID[1]);
-        gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, 4*particleCount, sizeBuffer);
+        gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, 4*particleCount, sizeBuffer.bytes);
         
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, 0);
     }
@@ -111,7 +109,7 @@ public class CCPointParticleSystem extends CCParticleSystem {
 
         gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, verticesID[1]);
         gl.glEnableClientState(GL11.GL_POINT_SIZE_ARRAY_OES);
-        gl.glPointSizePointerOES(GL11.GL_FLOAT, 0, sizeBuffer); // ccPointSprite.size
+        gl.glPointSizePointerOES(GL11.GL_FLOAT, 0, sizeBuffer.bytes); // ccPointSprite.size
 
 
         boolean newBlend = false;

--- a/cocos2d-android/src/org/cocos2d/particlesystem/CCQuadParticleSystem.java
+++ b/cocos2d-android/src/org/cocos2d/particlesystem/CCQuadParticleSystem.java
@@ -1,6 +1,5 @@
 package org.cocos2d.particlesystem;
 
-import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
 
 import javax.microedition.khronos.opengles.GL10;
@@ -17,6 +16,7 @@ import org.cocos2d.types.CGPoint;
 import org.cocos2d.types.CGRect;
 import org.cocos2d.types.ccBlendFunc;
 import org.cocos2d.utils.BufferProvider;
+import org.cocos2d.utils.FastFloatBuffer;
 
 /** CCQuadParticleSystem is a subclass of CCParticleSystem
 
@@ -35,9 +35,9 @@ import org.cocos2d.utils.BufferProvider;
 public class CCQuadParticleSystem extends CCParticleSystem implements Resource {
 	// ccV2F_C4F_T2F_Quad	quads;		// quads to be rendered
 
-	FloatBuffer         texCoords;
-	FloatBuffer         vertices;
-	FloatBuffer         colors;
+	FastFloatBuffer         texCoords;
+	FastFloatBuffer         vertices;
+	FastFloatBuffer         colors;
 
 	ShortBuffer			indices;	// indices
 	int					quadsIDs[];	// VBO id
@@ -51,9 +51,9 @@ public class CCQuadParticleSystem extends CCParticleSystem implements Resource {
 
 		// allocating data space
 		// quads = malloc( sizeof(quads[0]) * totalParticles );
-		texCoords	= BufferProvider.createFloatBuffer(4 * 2 * totalParticles);
-		vertices 	= BufferProvider.createFloatBuffer(4 * 2 * totalParticles);
-		colors  	= BufferProvider.createFloatBuffer(4 * 4 * totalParticles);
+		texCoords	= new FastFloatBuffer(4 * 2 * totalParticles);
+		vertices 	= new FastFloatBuffer(4 * 2 * totalParticles);
+		colors  	= new FastFloatBuffer(4 * 4 * totalParticles);
 		
 		indices = BufferProvider.createShortBuffer(totalParticles * 6 );
 
@@ -77,15 +77,15 @@ public class CCQuadParticleSystem extends CCParticleSystem implements Resource {
 				// initial binding
 				// for texCoords
 				gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, quadsIDs[0]);
-				gl.glBufferData(GL11.GL_ARRAY_BUFFER, texCoords.capacity() * 4, texCoords, GL11.GL_DYNAMIC_DRAW);	
+				gl.glBufferData(GL11.GL_ARRAY_BUFFER, texCoords.capacity() * 4, texCoords.bytes, GL11.GL_DYNAMIC_DRAW);	
 				
 				// for vertices
 				gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, quadsIDs[1]);
-				gl.glBufferData(GL11.GL_ARRAY_BUFFER, vertices.capacity() * 4, vertices, GL11.GL_DYNAMIC_DRAW);	
+				gl.glBufferData(GL11.GL_ARRAY_BUFFER, vertices.capacity() * 4, vertices.bytes, GL11.GL_DYNAMIC_DRAW);	
 				
 				// for colors
 				gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, quadsIDs[2]);
-				gl.glBufferData(GL11.GL_ARRAY_BUFFER, colors.capacity() * 4, colors, GL11.GL_DYNAMIC_DRAW);	
+				gl.glBufferData(GL11.GL_ARRAY_BUFFER, colors.capacity() * 4, colors.bytes, GL11.GL_DYNAMIC_DRAW);	
 				
 				// restore the elements, arrays
 				gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, 0);
@@ -284,15 +284,15 @@ public class CCQuadParticleSystem extends CCParticleSystem implements Resource {
 
 		// for texCoords
 		gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, quadsIDs[0]);
-		gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, texCoords.capacity() * 4, texCoords);	
+		gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, texCoords.capacity() * 4, texCoords.bytes);	
 		
 		// for vertices
 		gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, quadsIDs[1]);
-		gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, vertices.capacity() * 4, vertices);	
+		gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, vertices.capacity() * 4, vertices.bytes);	
 		
 		// for colors
 		gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, quadsIDs[2]);
-		gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, colors.capacity() * 4, colors);	
+		gl.glBufferSubData(GL11.GL_ARRAY_BUFFER, 0, colors.capacity() * 4, colors.bytes);	
 		
 		// restore the elements, arrays
 		gl.glBindBuffer(GL11.GL_ARRAY_BUFFER, 0);

--- a/cocos2d-android/src/org/cocos2d/tests/Box2dTest.java
+++ b/cocos2d-android/src/org/cocos2d/tests/Box2dTest.java
@@ -79,7 +79,7 @@ public class Box2dTest extends Activity {
         CCDirector.sharedDirector().setDisplayFPS(true);
 
         // frames per second
-        CCDirector.sharedDirector().setAnimationInterval(1.0f / 30.0f);
+        CCDirector.sharedDirector().setAnimationInterval(1.0f / 60.0f);
 
         CCScene scene = CCScene.node();
         scene.addChild(new Box2DTestLayer());
@@ -138,6 +138,10 @@ public class Box2dTest extends Activity {
         // Simulation space should be larger than window per Box2D recommendation.
         protected static final float BUFFER = 1.0f;
         
+        //FPS for the PhysicsWorld to sync to
+        protected static final float FPS = (float)CCDirector.sharedDirector().getAnimationInterval();
+        private static float rdelta = 0;
+        
         protected final World bxWorld;
         
         public Box2DTestLayer() {
@@ -149,7 +153,7 @@ public class Box2dTest extends Activity {
         	CGSize s = CCDirector.sharedDirector().winSize();
 
       		// Define the gravity vector.
-        	Vector2 gravity = new Vector2(0.0f, -10.0f);
+        	Vector2 gravity = new Vector2(9.8f, -9.8f);
 
         	float scaledWidth = s.width/PTM_RATIO;
             float scaledHeight = s.height/PTM_RATIO;
@@ -271,6 +275,8 @@ public class Box2dTest extends Activity {
 		
 
         public synchronized void tick(float delta) {
+        	if ((rdelta += delta) < FPS) return;
+        	
         	// It is recommended that a fixed time step is used with Box2D for stability
         	// of the simulation, however, we are using a variable time step here.
         	// You need to make an informed choice, the following URL is useful
@@ -279,9 +285,11 @@ public class Box2dTest extends Activity {
         	// Instruct the world to perform a simulation step. It is
         	// generally best to keep the time step and iterations fixed.
         	synchronized (bxWorld) {
-        		bxWorld.step(delta, 8, 1);
+        		bxWorld.step(FPS, 8, 1);
         	}
 	        	
+        	rdelta = 0;
+        	
         	// Iterate over the bodies in the physics world
         	Iterator<Body> it = bxWorld.getBodies();
         	while(it.hasNext()) {
@@ -324,7 +332,7 @@ public class Box2dTest extends Activity {
 			prevY = accY;		
 			
 			// no filtering being done in this demo (just magnify the gravity a bit)
-			gravity.set( accY * 1.0f, accX * -1.0f );
+			gravity.set( accY * 9.8f, accX * -9.8f );
 			bxWorld.setGravity( gravity );			
 		}
 		

--- a/cocos2d-android/src/org/cocos2d/utils/BufferProvider.java
+++ b/cocos2d-android/src/org/cocos2d/utils/BufferProvider.java
@@ -38,39 +38,39 @@ public class BufferProvider {
 		}
 	}
 	
-    public static void drawQuads(GL10 gl, FloatBuffer fbVert, FloatBuffer fbCoord) {
+    public static void drawQuads(GL10 gl, FastFloatBuffer fbVert, FastFloatBuffer fbCoord) {
         fbVert.position(0);
         fbCoord.position(0);
 
         gl.glEnableClientState(GL10.GL_VERTEX_ARRAY);
         gl.glEnableClientState(GL10.GL_TEXTURE_COORD_ARRAY);
-        gl.glVertexPointer(3, GL10.GL_FLOAT, 0, fbVert);
-        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, fbCoord);
+        gl.glVertexPointer(3, GL10.GL_FLOAT, 0, fbVert.bytes);
+        gl.glTexCoordPointer(2, GL10.GL_FLOAT, 0, fbCoord.bytes);
         gl.glDrawArrays(GL10.GL_TRIANGLE_STRIP, 0, 4);
         gl.glDisableClientState(GL10.GL_TEXTURE_COORD_ARRAY);
         gl.glDisableClientState(GL10.GL_VERTEX_ARRAY);
 
     }
 
-    public static void fillFloatBuffer(FloatBuffer fb, float[] arr) {
+    public static void fillFloatBuffer(FastFloatBuffer fb, float[] arr) {
         fb.position(0);
         fb.put(arr);
     }
 
-    public static FloatBuffer makeFloatBuffer(float[] arr) {
+    public static FastFloatBuffer makeFloatBuffer(float[] arr) {
         ByteBuffer bb = BufferProvider.allocateDirect(arr.length * 4);
         bb.order(ByteOrder.nativeOrder());
-        FloatBuffer fb = bb.asFloatBuffer();
+        FastFloatBuffer fb = FastFloatBuffer.createBuffer(bb);
         fb.put(arr);
         fb.position(0);
         return fb;
     }
 
-    public static FloatBuffer createFloatBuffer(int arrayElementCount) {
+    public static FastFloatBuffer createFloatBuffer(int arrayElementCount) {
         ByteBuffer temp = BufferProvider.allocateDirect(4 * arrayElementCount);
         temp.order(ByteOrder.nativeOrder());
         
-        return temp.asFloatBuffer();
+        return FastFloatBuffer.createBuffer(temp);
     }
     
     public static ByteBuffer createByteBuffer(int arrayElementCount) {

--- a/cocos2d-android/src/org/cocos2d/utils/FastFloatBuffer.java
+++ b/cocos2d-android/src/org/cocos2d/utils/FastFloatBuffer.java
@@ -1,0 +1,267 @@
+package org.cocos2d.utils;
+
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+/**
+ * Convenient work-around for poor {@link FloatBuffer#put(float[])} performance.
+ * This should become unnecessary in gingerbread, 
+ * @see <a href="http://code.google.com/p/android/issues/detail?id=11078">Issue 11078</a>
+ * 
+ * @author ryanm
+ */
+public class FastFloatBuffer {
+    /**
+     * Underlying data - give this to OpenGL
+     */
+    public ByteBuffer bytes;
+
+    private FloatBuffer floats;
+
+    private IntBuffer ints;
+
+    private int bufferID = -1;
+    private boolean loaded = false;
+
+    /**
+     * Use a {@link SoftReference} so that the array can be collected
+     * if necessary
+     */
+    private static SoftReference<int[]> intArray = new SoftReference<int[]>(
+            new int[0]);
+
+    public static FastFloatBuffer createBuffer(float[] data) {
+        FastFloatBuffer buffer = new FastFloatBuffer(data.length);
+        buffer.put(data);
+        buffer.position(0);
+        return buffer;
+    }
+    
+    public static FastFloatBuffer createBuffer(ByteBuffer buffer) {
+    	return new FastFloatBuffer(buffer);
+    }
+    
+    /**
+     * Constructs a new direct native-ordered buffer
+     * 
+     * @param capacity
+     *           the number of floats
+     */
+    public FastFloatBuffer(int capacity) {
+        bytes = ByteBuffer.allocateDirect((capacity * 4)).order(
+                ByteOrder.nativeOrder());
+        floats = bytes.asFloatBuffer();
+        ints = bytes.asIntBuffer();
+    }
+    
+    /**
+     * Constructs a new direct native-ordered buffer from
+     *  an existing ByteBuffer
+     * 
+     * @param buffer
+     * 			the existing ByteBuffer
+     */
+    public FastFloatBuffer(ByteBuffer buffer) {
+    	buffer.position(0);
+    	bytes = buffer;
+    	floats = bytes.asFloatBuffer();
+    	ints = bytes.asIntBuffer();
+    }
+    
+    
+    /**
+     * See {@link FloatBuffer#flip()}
+     */
+    public void flip() {
+        bytes.flip();
+        floats.flip();
+        ints.flip();
+    }
+
+    /**
+     * See {@link FloatBuffer#put(float)}
+     * 
+     * @param f
+     */
+    public FastFloatBuffer put(float f) {
+        bytes.position(bytes.position() + 4);
+        floats.put(f);
+        ints.position(ints.position() + 1);
+        
+        return this;
+    }
+
+    /**
+     * It's like {@link FloatBuffer#put(float[])}, but about 10 times
+     * faster
+     * 
+     * @param data
+     */
+    public FastFloatBuffer put(float[] data) {
+        int[] ia = intArray.get();
+        if (ia == null || ia.length < data.length) {
+            ia = new int[data.length];
+            intArray = new SoftReference<int[]>(ia);
+        }
+
+        for (int i = 0; i < data.length; i++) {
+            ia[i] = Float.floatToRawIntBits(data[i]);
+        }
+
+        bytes.position(bytes.position() + 4 * data.length);
+        floats.position(floats.position() + data.length);
+        ints.put(ia, 0, data.length);
+        
+        return this;
+    }
+
+    /**
+     * For use with pre-converted data. This is 50x faster than
+     * {@link #put(float[])}, and 500x faster than
+     * {@link FloatBuffer#put(float[])}, so if you've got float[] data
+     * that won't change, {@link #convert(float...)} it to an int[]
+     * once and use this method to put it in the buffer
+     * 
+     * @param data
+     *           floats that have been converted with
+     *           {@link Float#floatToIntBits(float)}
+     */
+    public FastFloatBuffer put(int[] data) {
+        bytes.position(bytes.position() + 4 * data.length);
+        floats.position(floats.position() + data.length);
+        ints.put(data, 0, data.length);
+        
+        return this;
+    }
+
+    /**
+     * Converts float data to a format that can be quickly added to the
+     * buffer with {@link #put(int[])}
+     * 
+     * @param data
+     * @return the int-formatted data
+     */
+    public static int[] convert(float... data) {
+        int[] id = new int[data.length];
+        for (int i = 0; i < data.length; i++) {
+            id[i] = Float.floatToRawIntBits(data[i]);
+        }
+
+        return id;
+    }
+
+    /**
+     * See {@link FloatBuffer#put(FloatBuffer)}
+     * 
+     * @param b
+     */
+    public FastFloatBuffer put(FastFloatBuffer b) {
+        bytes.put(b.bytes);
+        floats.position(bytes.position() >> 2);
+        ints.position(bytes.position() >> 2);
+        
+        return this;
+    }
+
+    /**
+     * @return See {@link FloatBuffer#capacity()}
+     */
+    public int capacity() {
+        return floats.capacity();
+    }
+
+    /**
+     * @return See {@link FloatBuffer#position()}
+     */
+    public int position() {
+        return floats.position();
+    }
+
+    /**
+     * See {@link FloatBuffer#position(int)}
+     * 
+     * @param p
+     */
+    public void position(int p) {
+        bytes.position(4 * p);
+        floats.position(p);
+        ints.position(p);
+    }
+
+    /**
+     * @return See {@link FloatBuffer#slice()}
+     */
+    public FloatBuffer slice() {
+        return floats.slice();
+    }
+
+    /**
+     * @return See {@link FloatBuffer#remaining()}
+     */
+    public int remaining() {
+        return floats.remaining();
+    }
+
+    /**
+     * @return See {@link FloatBuffer#limit()}
+     */
+    public int limit() {
+        return floats.limit();
+    }
+
+    /**
+     * See {@link FloatBuffer#clear()}
+     */
+    public void clear() {
+        bytes.clear();
+        floats.clear();
+        ints.clear();
+    }
+
+    public void setBufferID(int id) {
+        this .bufferID = id;
+    }
+
+    public int getBufferID() {
+        return this .bufferID;
+    }
+
+    public boolean isLoaded() {
+        return this .loaded;
+    }
+
+    public void setLoaded(boolean loaded) {
+        this.loaded = loaded;
+    }
+
+	public void put(int i, float f) {
+		final int j = this.position();
+		this.position(i);
+		this.put(f);
+		this.position(j);
+	}
+
+	public float get() {
+		return floats.get();
+	}
+
+	public float get(int i) {
+		return floats.get(i);
+	}
+
+	public void get(float[] ret, int i, int limit) {
+		floats.get(ret, i, limit);
+	}
+
+	public void put(float[] floats, int off, int len) {
+		for (int i = off; i < off + len; i++)
+	         this.put(floats[i]); 
+	}
+
+	public void rewind() {
+		this.position(0);
+	}
+}


### PR DESCRIPTION
There is a bug in which Android's implementation of FloatBuffer.put() is very, very expensive.  The performance issues are documented in this thread:

http://www.java-gaming.org/index.php?topic=22541.0

In that thread, Ryan McNally (ryanm) proposes a drop in replacement which wraps the methods of FloatBuffer.  I extended that (couldn't find a source project) for the use cases I found in the cocos2d project.  The result is that everything is much faster and smoother.

After 2.3 is commonplace it should be okay to remove the FastFloatBuffer class, but as for my company, we work on Android 2.2 and the bug was cripplingly slow.
