### PR TITLE
Fixed a bug with CCBezierTo

### DIFF
--- a/cocos2d-android/default.properties
+++ b/cocos2d-android/default.properties
@@ -7,7 +7,7 @@
 # "build.properties", and override values to adapt the script to your
 # project structure.
 
-android.library=false
+android.library=true
 # Indicates whether an apk should be generated for each density.
 split.density=false
 # Project target.

--- a/cocos2d-android/src/org/cocos2d/actions/interval/CCBezierTo.java
+++ b/cocos2d-android/src/org/cocos2d/actions/interval/CCBezierTo.java
@@ -9,6 +9,11 @@ import org.cocos2d.types.CGPoint;
  */
 public class CCBezierTo extends CCBezierBy {
 
+	/** We need to record the original config.  Repeating a bezier movement is continually
+	 *  more and more distorted if we continue to subtract the start position.
+	 */
+	final CCBezierConfig originalconfig;
+	
     /** creates the action with a duration and a bezier configuration */
     public static CCBezierTo action(float t, CCBezierConfig c) {
         return new CCBezierTo(t, c);
@@ -17,6 +22,10 @@ public class CCBezierTo extends CCBezierBy {
     /** initializes the action with a duration and a bezier configuration */
     protected CCBezierTo(float t, CCBezierConfig c) {
         super(t, c);
+        originalconfig = new CCBezierConfig();
+        originalconfig.controlPoint_1 = CGPoint.ccp(c.controlPoint_1.x, c.controlPoint_1.y);
+        originalconfig.controlPoint_2 = CGPoint.ccp(c.controlPoint_2.x, c.controlPoint_2.y);
+        originalconfig.endPosition = CGPoint.ccp(c.endPosition.x, c.endPosition.y);
     }
 
     @Override
@@ -28,9 +37,9 @@ public class CCBezierTo extends CCBezierBy {
     public void start(CCNode aTarget) {
         super.start(aTarget);
 
-        config.controlPoint_1 = CGPoint.ccpSub(config.controlPoint_1, startPosition);
-        config.controlPoint_2 = CGPoint.ccpSub(config.controlPoint_2, startPosition);
-        config.endPosition = CGPoint.ccpSub(config.endPosition, startPosition);
+        config.controlPoint_1 = CGPoint.ccpSub(originalconfig.controlPoint_1, startPosition);
+        config.controlPoint_2 = CGPoint.ccpSub(originalconfig.controlPoint_2, startPosition);
+        config.endPosition = CGPoint.ccpSub(originalconfig.endPosition, startPosition);
     }
 
     @Override

--- a/cocos2d-android/src/org/cocos2d/nodes/CCSprite.java
+++ b/cocos2d-android/src/org/cocos2d/nodes/CCSprite.java
@@ -433,6 +433,7 @@ public class CCSprite extends CCNode implements CCRGBAProtocol, CCTextureProtoco
     /** updates the texture rect of the CCSprite.
     */
 
+    
 	public void setTextureRect(float x, float y, float w, float h, Boolean rotated) {
     	setTextureRect(x, y, w, h, w, h, rotated);
     }

--- a/cocos2d-android/src/org/cocos2d/tests/Box2dTest.java
+++ b/cocos2d-android/src/org/cocos2d/tests/Box2dTest.java
@@ -298,8 +298,9 @@ public class Box2dTest extends Activity {
         		
         		if (userData != null && userData instanceof CCSprite) {
         			//Synchronize the Sprites position and rotation with the corresponding body
-        			CCSprite sprite = (CCSprite)userData;
-        			sprite.setPosition(b.getPosition().x * PTM_RATIO, b.getPosition().y * PTM_RATIO);
+        			final CCSprite sprite = (CCSprite)userData;
+        			final Vector2 pos = b.getPosition();
+        			sprite.setPosition(pos.x * PTM_RATIO, pos.y * PTM_RATIO);
         			sprite.setRotation(-1.0f * ccMacros.CC_RADIANS_TO_DEGREES(b.getAngle()));
         		}	
         	}


### PR DESCRIPTION
If you repeat a CCBezierTo action, then the CCBezierConfig.endPoint is continually distorted from repeatedly subtracting target.getPosition() from config.endPoint.

The solution was to copy the CCBezierConfig into a new variable which is unaltered.  This way you calculate the relative endPoints based on the original endPoint, not the previous relative endPoint.
